### PR TITLE
chore([DST-1435]): supply-chain hardening — 7-day cooldown + pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+minimum-release-age=10080
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "homepage": "https://github.com/marigold-ui/starter#readme",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
   "devDependencies": {
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "homepage": "https://github.com/marigold-ui/starter#readme",
-  "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
+  "packageManager": "pnpm@11.1.2",
   "devDependencies": {
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: true
 packages:
   - 'src/*'

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "packageRules": [
     {
       "matchDatasources": ["npm"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "marigold",


### PR DESCRIPTION
## Summary
Two layers of supply-chain hardening, plus the pnpm bump that goes with it:

**`.npmrc` (new)**
- `minimum-release-age=10080` (7 days, in minutes) — pnpm refuses to install any package version younger than a week, closing the manual `pnpm add` gap that Renovate alone cannot cover.
- `save-exact=true` — `package.json` stays on pinned versions.

**`renovate.json`**
- Bump `minimumReleaseAge` from 3 → 7 days so its PRs align with the new floor instead of being blocked at install time.

**`package.json` / `pnpm-workspace.yaml`**
- Bump pnpm to `11.1.2` (current `latest`).
- pnpm 11 removed `onlyBuiltDependencies`; migrate to the new `allowBuilds: { esbuild: true }` syntax. Without this pnpm 11 hard-errors (`ERR_PNPM_IGNORED_BUILDS`) on install instead of just warning.

### Why this shape
Supply-chain attacks on npm typically rely on a freshly-published malicious version being installed before the community notices and yanks it. A 7-day cooldown lets that detection window elapse before the version can land in our lockfile. Renovate's `minimumReleaseAge` only governs its own PRs — the `.npmrc` setting enforces the same floor for every human and CI install, which is the defense-in-depth piece. Mirrors the approach from core/main MR !33699.

## Test plan
- [x] `corepack pnpm install` succeeds under pnpm 11.1.2 against the current lockfile
- [x] `corepack pnpm build` produces a clean vite build
- [ ] Next Renovate run honours the new `7 days` floor on its PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)