### PR TITLE
fix(DST-1479): update CLAUDE.md to new Marigold doc URL structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ For layout, use these Marigold components instead of raw `<div>` with Tailwind. 
 
 ### Forms
 
-Wrap fields in a vertical `<Stack>` layout. Place the submit `<Button>` at the bottom-left. Fetch the [forms pattern doc](https://www.marigold-ui.io/patterns/forms.md) for spacing tokens and full guidance.
+Wrap fields in a vertical `<Stack>` layout. Place the submit `<Button>` at the bottom-left. Fetch the [forms pattern doc](https://www.marigold-ui.io/patterns/user-input/forms.md) for spacing tokens and full guidance.
 
 ### React Aria Foundation
 
@@ -92,7 +92,7 @@ Marigold is built on [React Aria](https://react-spectrum.adobe.com/react-aria/).
 
 Marigold provides AI-optimized markdown docs accessible directly via URL. **Start with the manifest** — it lists every doc page (components, foundations, patterns, getting started) with category, description, and markdown URL.
 
-**Manifest:** `https://www.marigold-ui.io/api/manifest.json`
+**Manifest:** `https://www.marigold-ui.io/manifest.json`
 
 Each entry has the shape `{ name, slug, category, description, badge, url }`. Resolve the component you need to its `url`, then fetch `https://www.marigold-ui.io{url}` to get the markdown.
 
@@ -100,7 +100,7 @@ Slugs use **kebab-case** for multi-word names (e.g. `DatePicker` → `date-picke
 
 Examples (resolved via the manifest):
 
-- Component: `https://www.marigold-ui.io/api/md/components/overlay/dialog.md`
-- Foundation: `https://www.marigold-ui.io/api/md/foundations/form-fields.md`
-- Pattern: `https://www.marigold-ui.io/api/md/patterns/forms.md`
-- Getting Started: `https://www.marigold-ui.io/api/md/getting-started/installation.md`
+- Component: `https://www.marigold-ui.io/components/overlay/dialog.md`
+- Foundation: `https://www.marigold-ui.io/foundations/form-fields.md`
+- Pattern: `https://www.marigold-ui.io/patterns/user-input/forms.md`
+- Getting Started: `https://www.marigold-ui.io/getting-started/installation.md`


### PR DESCRIPTION
## Summary

The Marigold docs site changed its URL structure. This updates all references in `CLAUDE.md`:

- **Manifest:** `/api/manifest.json` → `/manifest.json`
- **Doc URLs:** dropped the `/api/md` prefix (component / foundation / pattern / getting-started)
- **Forms pattern:** patterns now live under sub-categories, so the forms doc moved to `/patterns/user-input/forms.md` (the old `/patterns/forms.md` returned a stub)

The manifest `url` field now contains the bare path (e.g. `/components/overlay/dialog.md`), so the `https://www.marigold-ui.io{url}` resolution line still holds.

## Verification

Every URL was fetched against the live site and confirmed to return valid markdown:

| URL | Status |
|-----|--------|
| `…/manifest.json` | ✅ |
| `…/components/overlay/dialog.md` | ✅ |
| `…/foundations/form-fields.md` | ✅ |
| `…/getting-started/installation.md` | ✅ |
| `…/patterns/user-input/forms.md` | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)