### PR TITLE
fix: load Marigold styles in StackBlitz (DST-1499)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-
-src/vendor

--- a/copy-vendor.js
+++ b/copy-vendor.js
@@ -2,8 +2,12 @@
 import fs from 'fs';
 import path from 'path';
 
+// Tailwind v4 only extracts utility classes from these compiled library files
+// when the @source path lives inside node_modules. Copying the symlinked
+// @marigold packages to a real (dereferenced) folder there makes scanning work
+// in StackBlitz/WebContainer, which doesn't follow pnpm's symlinks.
 const source = path.resolve('node_modules/@marigold');
-const destination = path.resolve('src/vendor/marigold');
+const destination = path.resolve('node_modules/.marigold-src');
 
 // 1. Clean previous copy
 if (fs.existsSync(destination)) {
@@ -22,7 +26,7 @@ try {
     const destPath = path.join(destination, pkg);
     fs.cpSync(realPath, destPath, { recursive: true, dereference: true });
   }
-  console.log('✅ Marigold styles copied to src/vendor/marigold');
+  console.log('✅ Marigold styles copied to node_modules/.marigold-src');
 } catch (err) {
   console.error('❌ Failed to copy styles:', err.message);
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,11 @@
   },
   "scripts": {
     "copy-styles": "node copy-vendor.js",
-    "dev": "pnpm run copy-styles && vite",
+    "predev": "node copy-vendor.js",
+    "dev": "vite",
+    "prebuild": "node copy-vendor.js",
     "build": "vite build",
+    "prepreview": "node copy-vendor.js",
     "preview": "vite preview"
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,15 @@
 @import 'tailwindcss';
 @import '@marigold/theme-rui/theme.css';
 
-/* 
-Point to the local copy to make Marigold work.
-Workaround for current Issue: https://github.com/stackblitz/core/issues/3440
+/*
+Point Tailwind at a real (symlink-free) copy of the Marigold packages so class
+scanning works in StackBlitz/WebContainer, which doesn't follow pnpm's symlinks.
+The copy is created by copy-vendor.js (runs before dev/build/preview).
+Workaround for: https://github.com/stackblitz/core/issues/3440
 */
-@source "./vendor/marigold";
+@source '../node_modules/.marigold-src';
 
 /*
-needed for local environment
+Fallback for local environments where Tailwind can follow the pnpm symlinks.
 */
 @source '../node_modules/@marigold';


### PR DESCRIPTION
## Problem

Opening the starter in StackBlitz renders an **unstyled app** — none of the Marigold/Tailwind utilities are generated.

## Root cause

All ~144 KB of Marigold styles come from Tailwind v4 scanning `@source '../node_modules/@marigold'` in `src/index.css`. Two compounding issues:

1. **The `src/vendor` workaround contributed nothing.** Tailwind v4 only extracts utility classes from Marigold's compiled `.mjs`/`.cjs` files when the `@source` path lives **inside `node_modules`**. Identical files copied to `src/vendor/marigold` are ignored by the content scanner (verified — 0 bytes added).
2. **The working source is symlinked.** `node_modules/@marigold/*` are pnpm symlinks into the `.pnpm` store. Locally Tailwind follows them, but StackBlitz/WebContainer does not ([stackblitz/core#3440](https://github.com/stackblitz/core/issues/3440)), so the only load-bearing source yields nothing.

## Fix

- `copy-vendor.js` copies the dereferenced (symlink-free) packages to `node_modules/.marigold-src` instead of `src/vendor/marigold`.
- `src/index.css` points `@source` at `../node_modules/.marigold-src` (kept `../node_modules/@marigold` as the local-dev fallback).
- `package.json` runs the copy via `predev`/`prebuild`/`prepreview` hooks — package-manager-agnostic, no longer depends on `pnpm` being on PATH.
- Removed the stale `src/vendor` `.gitignore` entry.

## Verification

- `pnpm build` generates the full **143,935 bytes** of CSS.
- Simulating the StackBlitz condition (only the `.marigold-src` source feeds Tailwind) also yields **143,935 bytes** — the previously broken case now works.

Jira: [DST-1499](https://reservix.atlassian.net/browse/DST-1499)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DST-1499]: https://reservix.atlassian.net/browse/DST-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ