### PR TITLE
fix: inline copy-vendor so StackBlitz actually copies Marigold styles (DST-1499)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "scripts": {
     "copy-styles": "node copy-vendor.js",
-    "dev": "node copy-vendor.js && vite",
-    "build": "node copy-vendor.js && vite build",
-    "preview": "node copy-vendor.js && vite preview"
+    "dev": "pnpm run copy-styles && vite",
+    "build": "pnpm run copy-styles && vite build",
+    "preview": "pnpm run copy-styles && vite preview"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,8 @@
   },
   "scripts": {
     "copy-styles": "node copy-vendor.js",
-    "predev": "node copy-vendor.js",
-    "dev": "vite",
-    "prebuild": "node copy-vendor.js",
-    "build": "vite build",
-    "prepreview": "node copy-vendor.js",
-    "preview": "vite preview"
+    "dev": "node copy-vendor.js && vite",
+    "build": "node copy-vendor.js && vite build",
+    "preview": "node copy-vendor.js && vite preview"
   }
 }


### PR DESCRIPTION
Follow-up to #524.

## Problem

#524 fixed the StackBlitz style issue by running `copy-vendor.js` via pnpm `predev`/`prebuild`/`prepreview` lifecycle hooks. That works locally, but **StackBlitz's WebContainer does not run pnpm's `pre`/`post` hooks** — so on a fresh StackBlitz `pnpm install && pnpm run dev`, the copy never runs and the app is unstyled again (it only worked when running `predev` manually). Confirmed by @sarahgm testing in StackBlitz.

## Fix

Inline the copy into each script instead of relying on hooks:

```json
"dev": "node copy-vendor.js && vite",
"build": "node copy-vendor.js && vite build",
"preview": "node copy-vendor.js && vite preview"
```

The copy is now part of the command itself, so it runs regardless of hook support and without depending on `pnpm` being on PATH.

## Verification

`pnpm run dev` runs the copy before Vite:

```
$ node copy-vendor.js && vite
✅ Marigold styles copied to node_modules/.marigold-src

  VITE v8.0.16  ready in 256 ms
```

Jira: [DST-1499](https://reservix.atlassian.net/browse/DST-1499)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DST-1499]: https://reservix.atlassian.net/browse/DST-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ