### PR TITLE
chore(DST-1694): update starter to Marigold 18.0.0-rc.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,17 @@
     "vite": "8.1.5"
   },
   "dependencies": {
-    "@marigold/components": "17.9.1",
-    "@marigold/icons": "1.3.45",
-    "@marigold/system": "17.9.1",
-    "@marigold/theme-rui": "5.5.1",
+    "@marigold/components": "18.0.0-rc.5",
+    "@marigold/icons": "2.0.0-rc.5",
+    "@marigold/system": "18.0.0-rc.5",
+    "@marigold/theme-rui": "6.0.0-rc.5",
     "@tailwindcss/vite": "4.3.3",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "scripts": {
     "copy-styles": "node copy-vendor.js",
+    "typecheck": "tsc --noEmit",
     "dev": "pnpm run copy-styles && vite",
     "build": "pnpm run copy-styles && vite build",
     "preview": "pnpm run copy-styles && vite preview"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ importers:
   .:
     dependencies:
       '@marigold/components':
-        specifier: 17.9.1
-        version: 17.9.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        specifier: 18.0.0-rc.5
+        version: 18.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@marigold/icons':
-        specifier: 1.3.45
-        version: 1.3.45(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        specifier: 2.0.0-rc.5
+        version: 2.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@marigold/system':
-        specifier: 17.9.1
-        version: 17.9.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        specifier: 18.0.0-rc.5
+        version: 18.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@marigold/theme-rui':
-        specifier: 5.5.1
-        version: 5.5.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)(typescript@6.0.3)
+        specifier: 6.0.0-rc.5
+        version: 6.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)(typescript@6.0.3)
       '@tailwindcss/vite':
         specifier: 4.3.3
         version: 4.3.3(vite@8.1.5(jiti@2.7.0))
@@ -176,11 +176,17 @@ packages:
   '@internationalized/date@3.12.2':
     resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
 
+  '@internationalized/date@3.12.3':
+    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+
   '@internationalized/message@3.1.9':
     resolution: {integrity: sha512-x03MSVTaB/4JHtW1VAYaY/2cCuBrHbWM6ZvlgpKdnSdW28tZbqpR673RJrVJyXWRw1bpgYN89Tz7ohX5tgNgPA==}
 
   '@internationalized/number@3.6.7':
     resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.10':
+    resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
 
   '@internationalized/string@3.2.9':
     resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
@@ -201,25 +207,25 @@ packages:
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
-  '@marigold/components@17.9.1':
-    resolution: {integrity: sha512-kpv8f3mcMi3KfjHlyTUIkL5vyusAWntcUzFa0OMA01SFyproLTpQ+xya3LiPKRmwvoJTdFbVflwHSK2LgDGO7A==}
+  '@marigold/components@18.0.0-rc.5':
+    resolution: {integrity: sha512-f4ztyv42aJn1PARrlxRlCOmI/lSGrs7Uf9RByEuD3zuauC77PEVn+IqnFzYgyz0C+NazmWigRXhRRB/p+zkYNA==}
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
 
-  '@marigold/icons@1.3.45':
-    resolution: {integrity: sha512-tqA7gMvnJhk+FJGc3VJsCysix5YftQGFybHR7nFF43NiW8HXkjeiDkTZww6/5kun67AU5cWWtirYtYcmmpy+yQ==}
+  '@marigold/icons@2.0.0-rc.5':
+    resolution: {integrity: sha512-ct8XSaS0TDkV6Rcmnmqux7k9YQRSuS9zeZ+4ri6sC88s/dODrKo4Wr6dYGxGtdLOxqH+md/6LYtQDyJvDx09dQ==}
     peerDependencies:
-      react: '>=17.0.0'
+      react: '>=19.0.0'
 
-  '@marigold/system@17.9.1':
-    resolution: {integrity: sha512-AB0ugw7IcG1lLeJtcoftbTxqul5EK1iCHDfHDg9gHrRuv+RlIK7LdokgiRwbRrMUQBBrxcclR44vClq/AKb+6Q==}
+  '@marigold/system@18.0.0-rc.5':
+    resolution: {integrity: sha512-k+yWwURSHBIFOs0cy/38vqt9T6ZpkW70IM/rAjXbRwtG5W2qXNt8T1sHlkuB5eEmeYJ1PNLwtYKZH4P7+qweWA==}
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
 
-  '@marigold/theme-rui@5.5.1':
-    resolution: {integrity: sha512-Q8nWH/+tgQvCD7lYJKhAO9AS2pv4O35l9yLNilcZDgwcIEXs8CJlwu2LHyjSasJfrQcbhgVdcLG12mINNaYpdA==}
+  '@marigold/theme-rui@6.0.0-rc.5':
+    resolution: {integrity: sha512-i9ppO+lMjgN0ey2L88CaKSFwjrChVx9R1rJsUqzYqCbad2wrmK5q5CtXB4EB+fxPuLhlMmsCR/EfuGexmQbS1Q==}
 
   '@marigold/types@1.4.0':
     resolution: {integrity: sha512-WdHpvpjhXgEd5Oc7kZfvAyz4GW3rwHFK7p99odVq3NngdldEGRoJ8nSKJ3PMKdvHuO+YQeHsXKf9Qs+S3VOPaQ==}
@@ -259,6 +265,12 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-aria/form@3.2.1':
+    resolution: {integrity: sha512-uSNi8/lSFTMPGHzCeAPmFVQ8h8rRulInSVdstRL3hFmyjEOd2gGeKHwssCcLHmujy3T+K/AGeOQiKFpz2hjZEw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@react-aria/i18n@3.13.1':
     resolution: {integrity: sha512-z56ZYcbfpNmMyiGLhyEjytpmEfoTlBaksk84q4kds3HvNkf7QWKj+DJVfVDrJX+c1LyuBsszLSX7yxJRiHsYKQ==}
     peerDependencies:
@@ -279,6 +291,12 @@ packages:
 
   '@react-aria/landmark@3.1.1':
     resolution: {integrity: sha512-Njn/UVrCb2BPW1CPLHA1vrH51+ug62xLMNGUu2qtYj1rAxkLG1m3151hewgcxYtpmPxYlnRtOAmSuu/oD5YTFA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/live-announcer@3.5.1':
+    resolution: {integrity: sha512-kLvwHjM3D7KgdquiAhUpRnMLKFrvl2r8naDXqPUlSWGRG15wsJRLhQOHLxGp0Umyg7KcSA+OD1mhQV5aRv0P1w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -332,6 +350,12 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-stately/form@3.3.1':
+    resolution: {integrity: sha512-Wz5CK6X4bUo+VBUZLTrRDMXVdlTUVvQbaWTBzINf1zDeiNvGRsnv43L4OSQu/y9xfbtzJz/m2SH2ZTu1//aQXg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@react-stately/overlays@3.7.1':
     resolution: {integrity: sha512-vGw9f8i5kPvaQqvvQ8iIhPhJZorwtg2rXycqnUNXkNLadewh1S0ocbnRvrb4HW/GGC37rFmGcG1fYCHA/WIn6w==}
     peerDependencies:
@@ -373,6 +397,11 @@ packages:
 
   '@react-types/shared@3.35.0':
     resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/shared@3.36.1':
+    resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -725,8 +754,8 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  framer-motion@12.40.0:
-    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+  framer-motion@12.43.0:
+    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -867,20 +896,25 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lucide-react@1.28.0:
+    resolution: {integrity: sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
-  motion-dom@12.40.0:
-    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+  motion-dom@12.43.0:
+    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
 
   motion-utils@12.39.0:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
-  motion@12.39.0:
-    resolution: {integrity: sha512-H4a+Ze+a9j+/NTla5ezfb/g9vmIOxC+viDj++NGDZyTZkdRKjiOz3kSv6TalRWM8ZmD2y/CfC6TkQc97ybyqSA==}
+  motion@12.43.0:
+    resolution: {integrity: sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -941,14 +975,20 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  react-aria-components@1.18.0:
-    resolution: {integrity: sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==}
+  react-aria-components@1.20.0:
+    resolution: {integrity: sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react-aria@3.49.0:
     resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.51.0:
+    resolution: {integrity: sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -972,6 +1012,11 @@ packages:
 
   react-stately@3.47.0:
     resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-stately@3.49.0:
+    resolution: {integrity: sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -1294,12 +1339,20 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.19
 
+  '@internationalized/date@3.12.3':
+    dependencies:
+      '@swc/helpers': 0.5.19
+
   '@internationalized/message@3.1.9':
     dependencies:
       '@swc/helpers': 0.5.19
       intl-messageformat: 10.7.18
 
   '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.19
+
+  '@internationalized/string@3.2.10':
     dependencies:
       '@swc/helpers': 0.5.19
 
@@ -1326,19 +1379,21 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@marigold/components@17.9.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+  '@marigold/components@18.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
     dependencies:
-      '@internationalized/date': 3.12.2
-      '@marigold/system': 17.9.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@internationalized/date': 3.12.3
+      '@marigold/system': 18.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@marigold/types': 1.4.0(@types/react@19.2.17)
       '@react-aria/button': 3.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/calendar': 3.10.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/collections': 3.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/focus': 3.22.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@react-aria/form': 3.2.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/i18n': 3.13.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/interactions': 3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/label': 3.8.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/landmark': 3.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@react-aria/live-announcer': 3.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/overlays': 3.32.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/selection': 3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/ssr': 3.10.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1347,6 +1402,7 @@ snapshots:
       '@react-aria/visually-hidden': 3.9.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-stately/collections': 3.13.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-stately/data': 3.16.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@react-stately/form': 3.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-stately/overlays': 3.7.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-stately/table': 3.16.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-stately/tree': 3.10.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1354,11 +1410,11 @@ snapshots:
       '@react-types/button': 3.15.1(react@19.2.8)
       '@react-types/checkbox': 3.10.4(react@19.2.8)
       '@react-types/grid': 3.3.8(react@19.2.8)
-      '@react-types/shared': 3.35.0(react@19.2.8)
+      '@react-types/shared': 3.36.1(react@19.2.8)
       '@react-types/table': 3.13.6(react@19.2.8)
-      motion: 12.39.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
-      react-aria-components: 1.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-aria-components: 1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
       react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
@@ -1367,16 +1423,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@marigold/icons@1.3.45(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+  '@marigold/icons@2.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
     dependencies:
-      '@marigold/system': 17.9.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@marigold/system': 18.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      lucide-react: 1.28.0(react@19.2.8)
       react: 19.2.8
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - typescript
 
-  '@marigold/system@17.9.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+  '@marigold/system@18.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
     dependencies:
       '@marigold/types': 1.4.0(@types/react@19.2.17)
       '@react-aria/i18n': 3.13.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1390,10 +1447,10 @@ snapshots:
       - '@types/react'
       - typescript
 
-  '@marigold/theme-rui@5.5.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)(typescript@6.0.3)':
+  '@marigold/theme-rui@6.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)(typescript@6.0.3)':
     dependencies:
-      '@marigold/components': 17.9.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
-      '@marigold/system': 17.9.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@marigold/components': 18.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@marigold/system': 18.0.0-rc.5(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       tailwindcss-react-aria-components: 2.1.1(tailwindcss@4.3.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -1447,6 +1504,13 @@ snapshots:
       react-aria: 3.49.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
 
+  '@react-aria/form@3.2.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@swc/helpers': 0.5.19
+      react: 19.2.8
+      react-aria: 3.49.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+
   '@react-aria/i18n@3.13.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@internationalized/date': 3.12.2
@@ -1473,6 +1537,13 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@react-aria/landmark@3.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@swc/helpers': 0.5.19
+      react: 19.2.8
+      react-aria: 3.49.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@react-aria/live-announcer@3.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@swc/helpers': 0.5.19
       react: 19.2.8
@@ -1536,6 +1607,13 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       react-stately: 3.47.0(react@19.2.8)
 
+  '@react-stately/form@3.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@swc/helpers': 0.5.19
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.47.0(react@19.2.8)
+
   '@react-stately/overlays@3.7.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@swc/helpers': 0.5.19
@@ -1580,6 +1658,10 @@ snapshots:
       react: 19.2.8
 
   '@react-types/shared@3.35.0(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+
+  '@react-types/shared@3.36.1(react@19.2.8)':
     dependencies:
       react: 19.2.8
 
@@ -1831,9 +1913,9 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@12.40.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      motion-dom: 12.40.0
+      motion-dom: 12.43.0
       motion-utils: 12.39.0
       tslib: 2.8.1
     optionalDependencies:
@@ -1936,21 +2018,25 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lucide-react@1.28.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   memoize-one@6.0.0: {}
 
-  motion-dom@12.40.0:
+  motion-dom@12.43.0:
     dependencies:
       motion-utils: 12.39.0
 
   motion-utils@12.39.0: {}
 
-  motion@12.39.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      framer-motion: 12.40.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      framer-motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.8
@@ -1997,16 +2083,17 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  react-aria-components@1.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-aria-components@1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@internationalized/date': 3.12.2
-      '@react-types/shared': 3.35.0(react@19.2.8)
+      '@internationalized/date': 3.12.3
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
       '@swc/helpers': 0.5.19
       client-only: 0.0.1
       react: 19.2.8
-      react-aria: 3.49.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
-      react-stately: 3.47.0(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
 
   react-aria@3.49.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -2020,6 +2107,20 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       react-stately: 3.47.0(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
+  react-aria@3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.19
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
   react-dom@19.2.8(react@19.2.8):
@@ -2054,6 +2155,16 @@ snapshots:
       '@internationalized/number': 3.6.7
       '@internationalized/string': 3.2.9
       '@react-types/shared': 3.35.0(react@19.2.8)
+      '@swc/helpers': 0.5.19
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
+  react-stately@3.49.0(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
       '@swc/helpers': 0.5.19
       react: 19.2.8
       use-sync-external-store: 1.6.0(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,17 @@ allowBuilds:
   esbuild: true
 packages:
   - 'src/*'
+# Ported from .npmrc, which pnpm 11 no longer reads for anything but auth/registry.
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  # First-party packages, so the supply-chain cooldown adds no value here and
+  # would block prereleases (e.g. Marigold 18 RCs) for a week.
+  - '@marigold/*'
+  # React Aria and its satellites: Marigold tracks them closely, so a 7-day
+  # cooldown here blocks Marigold releases rather than gating anything useful.
+  - '@internationalized/*'
+  - '@react-aria/*'
+  - '@react-stately/*'
+  - '@react-types/*'
+  - 'react-aria*'
+  - 'react-stately*'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Button, Headline, Inset, Stack, Text } from '@marigold/components';
 
 export const App = () => (
-  <Inset space={10}>
+  <Inset p={10}>
     <Stack space={6} alignX="center">
       <Headline level={2}>Welcome to Marigold 🏵️</Headline>
       <Text>Start prototyping by editing this file.</Text>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
# Description

Brings the starter onto the Marigold 18 release candidate so prototyping happens against the upcoming major and RC issues surface early.

- `@marigold/components` + `@marigold/system` → `18.0.0-rc.5`
- `@marigold/theme-rui` → `6.0.0-rc.5`
- `@marigold/icons` → `2.0.0-rc.5` (now a `lucide-react` proxy; `lucide-react` is a real dependency of the package, not a peer, so nothing needed adding)
- `src/App.tsx`: `<Inset space={10}>` → `<Inset p={10}>`

Only one 18.x breaking change reaches the starter (Inset's `space`/`spaceX`/`spaceY` → `p`/`px`/`py`). The numeric value stays valid, since `p` accepts `Scale | InsetSpacingTokens`.

**Supply-chain config.** Porting the 7-day cooldown out of `.npmrc` surfaced that pnpm 11 reads nothing but auth/registry settings from that file — so the cooldown added in #500 was never actually enforced. Moving it into `pnpm-workspace.yaml` makes it real, which then blocked Marigold 18's React Aria dependencies (published inside the window, cf. DST-1680). Those plus `@marigold/*` are excluded.

**No `src/vendor` work needed.** The StackBlitz workaround it belonged to was superseded by `node_modules/.marigold-src` (#524), which regenerates on every build and picked up 18 automatically.

N/A for this repo: stories, changeset, VRT and a11y review — the starter has no Storybook, changesets or Chromatic.

Closes DST-1694

## Screenshots / Preview

theme-rui 6 moves the palette to warm charcoal and makes `--color-border` translucent, so the render shifts slightly. Not a regression.

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above. -->

## Test Instructions

1. `pnpm install` — resolves with no extra flags; the four Marigold packages land on their RC versions.
2. `pnpm typecheck` — clean. (New script; see below.)
3. `pnpm build` — succeeds. Emitted CSS is 190,893 bytes, up from the 143,935 baseline established in #524. Growth is expected from theme-rui 6's new tokens; a *collapse* would indicate Tailwind's scanning of `.marigold-src` broke.
4. `pnpm dev` — the page renders styled, "Get Started" fires its alert, console is clean.

## Breaking Changes

No — the starter publishes nothing, so there are no downstream consumers. It does *adopt* Marigold 18's breaking changes, but only Inset's rename touches this code.

Contributor-facing note: `pnpm-workspace.yaml` now enforces the 7-day cooldown that `.npmrc` silently wasn't, so unrelated dependency bumps may need an entry in `minimumReleaseAgeExclude`.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available — N/A
- [ ] Stories added/updated (with `component-test` tag where applicable) — N/A
- [ ] Unit tests added/updated — N/A (no test setup in this repo)
- [ ] Component documentation added/updated (if it exists) — N/A
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) — N/A (no component changes)
- [ ] Visual regression tests updated (for UI changes) — N/A (no Chromatic)
- [ ] Changeset added (`pnpm changeset`) — N/A (private package)
- [x] `pnpm install`, `pnpm typecheck` and `pnpm build` verified locally