### PR TITLE
chore(deps): bump nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8, high)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid: ^3.3.18
+
 importers:
 
   .:
@@ -804,8 +807,8 @@ packages:
       react-dom:
         optional: true
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1660,7 +1663,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-releases@2.0.51: {}
 
@@ -1672,7 +1675,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,9 @@ minimumReleaseAgeExclude:
   - '@react-types/*'
   - 'react-aria*'
   - 'react-stately*'
+
+overrides:
+  # GHSA-2v37-7h3g-55p8 (high): nanoid < 3.3.18 can loop indefinitely when a
+  # custom generator gets size 0. Reached only transitively via postcss.
+  # Drop this once postcss's own range floor moves past 3.3.18 on its own.
+  nanoid: '^3.3.18'

--- a/renovate.json
+++ b/renovate.json
@@ -30,5 +30,9 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "description": "A security patch must not sit in the supply-chain cooldown. GHSA-2v37-7h3g-55p8 was fixed in nanoid 3.3.18, but the 7-day minimumReleaseAge above skipped it and the resolver picked the still-vulnerable 3.3.17 instead.",
+    "minimumReleaseAge": null
+  }
 }


### PR DESCRIPTION
## Security — transitive only (1 package)

`nanoid` 3.3.16 → 3.3.18 — **GHSA-2v37-7h3g-55p8, high** (CWE-835): custom generators can loop indefinitely when `size` is zero.

`postcss` is **not** bumped. It stays at 8.5.25.

> **Note:** this PR previously bumped `postcss` to 8.5.26 to reach `nanoid@3.3.17`. That did not fix the advisory — the vulnerable range is `< 3.3.18`, so 3.3.17 is still affected. Caught in review by @sarahgm; rewritten on top of current main.

### Why nanoid alone, and not the parent

`nanoid` is not declared here. It is reached only through `postcss`:

```
nanoid@3.3.18
└─┬ postcss@8.5.25
  ├─┬ autoprefixer@10.5.4  → starter (devDependencies)
  └─┬ vite@8.2.1           → starter (+ @tailwindcss/vite, @vitejs/plugin-react)
```

`postcss@8.5.25` already declares `nanoid: "^3.3.16"`, and `3.3.18` satisfies that range. So the parent needs no bump, and no `minimumReleaseAgeExclude` carve-out is required either.

`nanoid` lands on **3.3.18**, the smallest patched version.

### Why an override rather than a lockfile re-resolve

pnpm will not re-resolve a transitive dependency that still satisfies its parent's range. Both narrower commands are no-ops here:

```
pnpm update nanoid --depth Infinity   →  "Already up to date", 0-line lockfile diff
pnpm dedupe                           →  "Already up to date", 0-line lockfile diff
```

And deleting the lockfile overshoots — it re-resolves everything:

```
pnpm-lock.yaml | 395 ++++++++-------------------
1 file changed, 168 insertions(+), 227 deletions(-)
```

That pulls in 14 unrelated transitive bumps: `baseline-browser-mapping`, `browserslist`, `caniuse-lite`, `cva`, `detect-libc`, `electron-to-chromium`, `enhanced-resolve`, `lucide-react`, `node-releases`, `postcss`, `rolldown`, `tailwindcss-react-aria-components`, `update-browserslist-db`. That would make this a general dependency bump rather than a security-only change.

So the override is the only mechanism that moves `nanoid` on its own:

```yaml
overrides:
  nanoid: '^3.3.18'
```

It is a floor, not a pin — `3.3.x` still floats — and it self-obsoletes once postcss's own range floor moves past `3.3.18`. The comment in `pnpm-workspace.yaml` says so.

### The cooldown is what caused this

The publish dates explain the original mistake:

```
nanoid 3.3.17   published 2026-08-03
nanoid 3.3.18   published 2026-08-07
```

When the first attempt was made on 2026-08-10, `3.3.18` was 3 days old. The repo's 7-day `minimumReleaseAge` skipped it, so the resolver settled on `3.3.17` — **the cooldown selected a vulnerable version.**

`renovate.json` also set `minimumReleaseAge: "7 days"` for all npm packages, so Renovate would hold the next security patch the same way. Fixed at the source instead of per-package:

```json
"vulnerabilityAlerts": {
  "minimumReleaseAge": null
}
```

Validated with `renovate-config-validator` (*Config validated successfully*).

The pnpm side keeps its blanket `minimumReleaseAge: 10080`, because `pnpm-workspace.yaml` has no way to express "except security patches". Renovate raising the PR is the path that matters in practice, but the gap is worth knowing about.

### Verification

| Step | Result |
|---|---|
| `pnpm install --frozen-lockfile` | pass (exit 0) — *Lockfile passes supply-chain policies* |
| `pnpm audit` | **No known vulnerabilities found** (exit 0) |
| `pnpm typecheck` | pass (exit 0) |
| `pnpm build` | pass (exit 0, 2177 modules) |
| `pnpm why nanoid` | `3.3.18` via `postcss@8.5.25` |

No lint or test script exists in this project; the gate is install → audit → typecheck → build.

No source files changed. Diff is 18 lines across 3 files. This PR contains no non-advisory package bumps.

### Not included

There is no CI workflow and no `audit` script, so nothing runs `pnpm audit` automatically — one CI step would have caught the original mistake. Left out of a security patch deliberately; worth a separate PR.
